### PR TITLE
change time measurement to be in seconds float64

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,13 +2,12 @@ package multilateration_test
 
 import (
 	"fmt"
-	"time"
 
 	multilat "github.com/hhhapz/multilateration"
 )
 
 func Example2D() {
-	n := time.Now() // source emission time
+	n := 0.0 // source emission time
 	source := multilat.TimePos2D{T: n, X: 50, Y: 50}
 
 	// generate positions based on source and stations. This simulates when stations will
@@ -25,11 +24,11 @@ func Example2D() {
 		fmt.Printf("error: could not multilaterate: %v\n", err)
 		return
 	}
-	fmt.Printf("multilaterated: (%.2f, %.2f) with time diff %s\n", source.X, source.Y, n.Sub(source.T))
+	fmt.Printf("multilaterated: (%.2f, %.2f)\n", source.X, source.Y)
 	// Output:
 	// source: (50.00, 50.00)
 	// station: (0.00, 0.00)
 	// station: (0.00, 100.00)
 	// station: (100.00, 0.00)
-	// multilaterated: (50.00, 50.00) with time diff 0s
+	// multilaterated: (50.00, 50.00)
 }

--- a/multilateration.go
+++ b/multilateration.go
@@ -2,14 +2,13 @@ package multilateration
 
 import (
 	"errors"
-	"time"
 )
 
 const c = 299_792_458 // m/s
 
-// meters to ns returns the duration it takes light to travel x meters in nanoseconds (time.Duration)
-func mToD(x float64) time.Duration {
-	return time.Duration(x / c * 1e9)
+// meters to s returns the duration it takes light to travel x meters in seconds
+func mToD(x float64) float64 {
+	return x / c
 }
 
 var ErrNotEnoughPoints = errors.New("not enough points to multilaterate")

--- a/multilateration_test.go
+++ b/multilateration_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 )
 
 func Test2D(t *testing.T) {
-	n := time.Now() // time of emission
+	n := 0.0 // time of emission
 	var tests = []struct {
 		source   Pos2D
 		stations []Pos2D
@@ -71,7 +70,7 @@ func Test2D(t *testing.T) {
 		if err != nil {
 			t.Errorf("could not multilaterate: %v", err)
 		}
-		t.Logf("multilaterated: (%.2f, %.2f) with time diff %s", source.X, source.Y, n.Sub(source.T))
+		t.Logf("multilaterated: (%.2f, %.2f) with time diff %v", source.X, source.Y, n-source.T)
 	}
 
 }


### PR DESCRIPTION
The minimum non subnormal float is ~= 4.1e-265 * plank time so this gives way too much precision but that better than the 1ns, since 1ns ~= 30cm.

This improve the precision of the position result: https://www.diffchecker.com/twf4UOMP/